### PR TITLE
Made the SetCurrentScene function more of a helper function

### DIFF
--- a/example/setCurrentScene.dart
+++ b/example/setCurrentScene.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:obs_websocket/obs_websocket.dart';
+import 'package:yaml/yaml.dart';
+
+void main(List<String> args) async {
+  final config = loadYaml(File('config.yaml').readAsStringSync());
+
+  ObsWebSocket obsWebSocket = await ObsWebSocket.connect(
+      connectUrl: config['host'],
+      timeout: const Duration(seconds: 5),
+      fallbackEvent: (event) {
+        print('event: ${event.rawEvent}');
+      });
+
+  final authRequired = await obsWebSocket.getAuthRequired();
+
+  if (authRequired.authRequired != false) {
+    await obsWebSocket.authenticate(authRequired, config['password']);
+  }
+
+  obsWebSocket.setCurrentScene('Intro');
+}

--- a/lib/src/obs_websocket.dart
+++ b/lib/src/obs_websocket.dart
@@ -366,8 +366,9 @@ class ObsWebSocket {
   }
 
   ///Switch to the specified scene.
-  Future<void> setCurrentScene(Map<String, dynamic> args) async {
-    await command('SetCurrentScene', args);
+  Future<void> setCurrentScene(String name) async {
+    var scene = <String, dynamic>{'scene-name': name};
+    await command('SetCurrentScene', scene);
   }
 
   ///Show or hide a specified source item in a specified scene.


### PR DESCRIPTION
Currently when you call SetCurrentScene you have to pass arguments so
```dart
var args = <String, String>{'scene-name':'amazingSceneHere'};
```

This will enable you to just pass a string as the name of the scene through

i have also included an example