### PR TITLE
Export SceneDetail class

### DIFF
--- a/lib/obs_websocket.dart
+++ b/lib/obs_websocket.dart
@@ -27,6 +27,7 @@ export 'src/model/response/stream_status_response.dart';
 export 'src/model/response/take_source_screenshot_response.dart';
 export 'src/model/response/stream_status_response.dart';
 export 'src/model/scene.dart';
+export 'src/model/scene_detail.dart';
 export 'src/model/scene_item.dart';
 export 'src/model/scene_item_property.dart';
 export 'src/model/source.dart';


### PR DESCRIPTION
Currently we have no access to SceneDetail class from the default package import, so i suggest to add scene_detail model to the exports.