### PR TITLE
Add onDone to the stream listener

### DIFF
--- a/lib/src/obs_websocket_base.dart
+++ b/lib/src/obs_websocket_base.dart
@@ -20,7 +20,7 @@ class ObsWebSocket {
   ///When the object is created we open the websocket connection and create a
   ///broadcast stream so that we can have multiple listeners providing responses
   ///to commands. [channel] is an existing [WebSocketChannel].
-  ObsWebSocket({required this.channel, Function? fallbackEvent}) {
+  ObsWebSocket({required this.channel, Function()? onDone}) {
     broadcast = channel.stream.asBroadcastStream();
 
     broadcast.listen((jsonEvent) {
@@ -29,14 +29,13 @@ class ObsWebSocket {
       if (!rawEvent.containsKey('message-id')) {
         _handleEvent(BaseEvent.fromJson(rawEvent));
       }
-    }, cancelOnError: true);
+    }, cancelOnError: true, onDone: onDone);
   }
 
   ///connect through io or html packages depending on runtime environment
   static Future<ObsWebSocket> connect(
       {required String connectUrl,
-      Function? fallbackEvent,
-      Function? onError,
+      Function()? onDone,
       Duration timeout = const Duration(seconds: 30)}) async {
     if (!connectUrl.startsWith('ws://')) {
       connectUrl = 'ws://$connectUrl';
@@ -46,7 +45,7 @@ class ObsWebSocket {
         await Connect().connect(connectUrl: connectUrl, timeout: timeout);
 
     return ObsWebSocket(
-        channel: webSocketChannel, fallbackEvent: fallbackEvent);
+        channel: webSocketChannel, onDone: onDone);
   }
 
   ///Before execution finished the websocket needs to be closed


### PR DESCRIPTION
Currently there is no way to detect if the websocket connection ended but we can use the onDone handler for that.

I removed the onError from the connect function as you use the cancelOnError: true, which as i understood will not call the error handler and cancel subscription at the first error.

It seems that fallbackEvent parameter was not used anywhere (hope i'm not wrong 😄), so i removed it to avoid user confusion with onDone.