### PR TITLE
Fix ObsWebsocket onDone

### DIFF
--- a/lib/src/obs_websocket_base.dart
+++ b/lib/src/obs_websocket_base.dart
@@ -19,6 +19,8 @@ class ObsWebSocket with UiLoggy {
 
   final eventHandlers = <String, List<Function>>{};
 
+  Function()? onStreamDone = () {};
+
   request.Config? _config;
 
   request.Filters? _filters;
@@ -126,6 +128,8 @@ class ObsWebSocket with UiLoggy {
     if (fallbackEventHandler != null) {
       addFallbackListener(fallbackEventHandler);
     }
+
+    onStreamDone = onDone;
   }
 
   static Future<ObsWebSocket> connect(
@@ -178,6 +182,8 @@ class ObsWebSocket with UiLoggy {
 
         _handleEvent(event);
       }
+    }, onDone: () {
+      onStreamDone?.call();
     });
 
     await authenticate();


### PR DESCRIPTION
Hi, if i'm not mistaken the onDone is currently useless as it is attached to nothing. So here I suggest to trigger the onDone function when the websocket stream listener actually trigger his onDone callback.

I also don't know if we should add the onError callback of the listener, it could be usefull ?